### PR TITLE
Add API to handle submitting new statements

### DIFF
--- a/components/AddNewStatement.js
+++ b/components/AddNewStatement.js
@@ -10,9 +10,33 @@ import {
   ModalCloseButton,
 } from '@chakra-ui/react';
 import { Textarea } from '@chakra-ui/textarea';
+import { useState } from 'react';
 
-export default function AddNewStatement() {
+export default function AddNewStatement({ jamId }) {
   const { isOpen, onOpen, onClose } = useDisclosure();
+  const [statement, setStatement] = useState();
+  const [submitted, setSubmitted] = useState(false);
+
+  const sendRequest = () => {
+    fetch('/api/statement', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ statement: statement, jamId: jamId }),
+    })
+      .then(() => {
+        setSubmitted(true);
+      })
+      .catch((error) =>
+        console.error('Error saving statement: ', error),
+      );
+  };
+
+  let handleInputChange = (e) => {
+    let inputValue = e.target.value;
+    setStatement(inputValue);
+  };
 
   return (
     <>
@@ -23,26 +47,62 @@ export default function AddNewStatement() {
       <Modal isOpen={isOpen} onClose={onClose}>
         <ModalOverlay />
         <ModalContent>
-          <ModalHeader>Submit statements for voting</ModalHeader>
-          <ModalCloseButton />
-          <ModalBody>
-            - Statements should be easy for everyone to understand
-            without further explanation.
-            <br />
-            - Keep them clear and under 140 characters long.
-            <br />- Each one should be unique and raise a different
-            point.
-            <Textarea
-              mt={5}
-              placeholder="Please enter your statement here"
-            />
-          </ModalBody>
-          <ModalFooter>
-            <Button mr={3} onClick={onClose}>
-              Cancel
-            </Button>
-            <Button colorScheme="blue">Submit</Button>
-          </ModalFooter>
+          {!submitted ? (
+            <>
+              <ModalHeader>Submit statements for voting</ModalHeader>
+              <ModalCloseButton />
+              <ModalBody>
+                - Statements should be easy for everyone to understand
+                without further explanation.
+                <br />
+                - Keep them clear and under 140 characters long.
+                <br />- Each one should be unique and raise a
+                different point.
+                <Textarea
+                  mt={5}
+                  placeholder="Please enter your statement here"
+                  value={statement}
+                  onChange={handleInputChange}
+                />
+              </ModalBody>
+              <ModalFooter>
+                <Button mr={3} onClick={onClose}>
+                  Cancel
+                </Button>
+                <Button
+                  colorScheme="blue"
+                  onClick={() => sendRequest()}
+                >
+                  Submit
+                </Button>
+              </ModalFooter>
+            </>
+          ) : (
+            <>
+              <ModalHeader>
+                Thank you for submitting a statement
+              </ModalHeader>
+              <ModalCloseButton />
+              <ModalBody>
+                One of our moderators will review your submission.
+              </ModalBody>
+              <ModalFooter>
+                <Button
+                  colorScheme="blue"
+                  mr={3}
+                  onClick={() => {
+                    setStatement('');
+                    setSubmitted(false);
+                  }}
+                >
+                  Submit another
+                </Button>
+                <Button colorScheme="blue" onClick={onClose}>
+                  Back to survey
+                </Button>
+              </ModalFooter>
+            </>
+          )}
         </ModalContent>
       </Modal>
     </>

--- a/pages/api/jam.js
+++ b/pages/api/jam.js
@@ -1,0 +1,33 @@
+import fire from '../../config/firebaseAdminConfig';
+
+export default function handler(req, res) {
+  const {
+    query: { jamUrlPath },
+    method,
+  } = req;
+
+  if (method !== 'GET') {
+    res.setHeader('Allow', ['GET']);
+    res.status(405).end(`Method ${method} Not Allowed`);
+  }
+
+  const db = fire.firestore();
+  const jamsRef = db.collection('jams');
+
+  console.log(jamUrlPath, 'jamUrlPath');
+  return new Promise(() => {
+    jamsRef
+      .where('urlPath', '==', jamUrlPath)
+      .get()
+      .then((querySnapshot) => {
+        querySnapshot.forEach((doc) => {
+          const jam = doc.data();
+          jam.key = doc.id;
+
+          res.status(200);
+          res.setHeader('Content-Type', 'application/json');
+          res.json(jam);
+        });
+      });
+  });
+}

--- a/pages/api/question.js
+++ b/pages/api/question.js
@@ -17,61 +17,53 @@ export default function handler(req, res) {
   const participantsRef = db.collection('participants');
 
   return new Promise(() => {
-    jamsRef
-      .where('urlPath', '==', jamId)
+    const questionsPromise = jamsRef
+      .doc(jamId)
+      .collection('statements')
       .get()
-      .then((querySnapshot) => {
-        querySnapshot.forEach((doc) => {
-          const questionsPromise = jamsRef
-            .doc(doc.id)
-            .collection('statements')
-            .get()
-            .then((query) => {
-              const questions = {};
-              query.forEach((question) => {
-                questions[question.id] = question.data();
-              });
-              return questions;
-            });
-
-          const votesPromise = participantsRef
-            .doc(participantId)
-            .collection('votes')
-            .get()
-            .then((query) => {
-              const allVotes = [];
-              query.forEach((vote) =>
-                allVotes.push(vote.data().statementId),
-              );
-              return allVotes;
-            });
-
-          Promise.all([questionsPromise, votesPromise]).then(
-            ([questions, votes]) => {
-              const unansweredQs = pickBy(
-                questions,
-                (value, key) => !votes.includes(key),
-              );
-
-              const keys = Object.keys(unansweredQs);
-              if (!keys.length) {
-                res.status(200);
-                res.setHeader('Content-Type', 'application/json');
-                res.json({});
-              } else {
-                const randomKey =
-                  keys[(keys.length * Math.random()) << 0];
-                const randomQ = unansweredQs[randomKey];
-                randomQ.key = randomKey;
-                randomQ.jamId = doc.id;
-
-                res.status(200);
-                res.setHeader('Content-Type', 'application/json');
-                res.json(randomQ);
-              }
-            },
-          );
+      .then((query) => {
+        const questions = {};
+        query.forEach((question) => {
+          questions[question.id] = question.data();
         });
+        return questions;
       });
+
+    const votesPromise = participantsRef
+      .doc(participantId)
+      .collection('votes')
+      .get()
+      .then((query) => {
+        const allVotes = [];
+        query.forEach((vote) =>
+          allVotes.push(vote.data().statementId),
+        );
+        return allVotes;
+      });
+
+    Promise.all([questionsPromise, votesPromise]).then(
+      ([questions, votes]) => {
+        const unansweredQs = pickBy(
+          questions,
+          (value, key) => !votes.includes(key),
+        );
+
+        const keys = Object.keys(unansweredQs);
+        if (!keys.length) {
+          res.status(200);
+          res.setHeader('Content-Type', 'application/json');
+          res.json({});
+        } else {
+          const randomKey = keys[(keys.length * Math.random()) << 0];
+          const randomQ = unansweredQs[randomKey];
+          randomQ.key = randomKey;
+          randomQ.jamId = jamId;
+
+          res.status(200);
+          res.setHeader('Content-Type', 'application/json');
+          res.json(randomQ);
+        }
+      },
+    );
   });
 }

--- a/pages/api/statement.js
+++ b/pages/api/statement.js
@@ -1,0 +1,31 @@
+import fire from '../../config/firebaseAdminConfig';
+
+export default function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', ['POST']);
+    res.status(405).end(`Method ${method} Not Allowed`);
+  }
+
+  const { jamId, statement } = req.body;
+  const db = fire.firestore();
+  const jamsRef = db.collection('jams');
+
+  return new Promise(() => {
+    jamsRef
+      .doc(jamId)
+      .collection('statements')
+      .add({
+        text: statement,
+        createdAt: fire.firestore.Timestamp.now(),
+        isUserSubmitted: true,
+        state: 0,
+        numAgrees: 0,
+        numDisagrees: 0,
+        numSkipped: 0,
+      })
+      .then(() => res.status(201).end())
+      .catch((error) => {
+        console.error('Error writing document: ', error);
+      });
+  });
+}

--- a/pages/jams/[jam].js
+++ b/pages/jams/[jam].js
@@ -136,7 +136,7 @@ const Jam = () => {
             </>
           )}
 
-          <AddNewStatement />
+          <AddNewStatement jamId={jam ? jam.key : null} />
         </Stack>
 
         <footer>


### PR DESCRIPTION
This PR contains 2 commits:
1. The first commit adds an `/api/jam` endpoint that is used to `GET` the Jam metadata and display this on the jam page, as well as storing the `jamId` for future requests. This also allows us to refactor the `/api/question` endpoint as we no longer have to lookup the jam by it's `urlPath` on each request as we now have the `jamId`.
2. The second commit adds the UI handling around submitting statements, one or more, and showing the correct modal depending on the state of the application.

Closes #24 