### PR TITLE
Get rid of next-auth errors when running tests

### DIFF
--- a/__tests__/testing-library.js
+++ b/__tests__/testing-library.js
@@ -1,18 +1,31 @@
 /**
  * @jest-environment jsdom
  */
-import React from 'react'
-import { render } from '@testing-library/react'
-import Index from '../pages/index'
+import React from 'react';
+import { render } from '@testing-library/react';
+import Index from '../pages/index';
+import client from 'next-auth/client';
+import '@testing-library/jest-dom';
+
+jest.mock('next-auth/client');
+
+beforeAll(() => {
+  const mockSession = {
+    expires: '1',
+    user: { email: 'jam', name: 'jam' },
+  };
+
+  client.useSession.mockReturnValueOnce([mockSession, false]);
+});
 
 describe('App', () => {
   it('renders a heading', () => {
-    const { getByRole } = render(<Index />)
+    const { getByRole } = render(<Index />);
 
     const heading = getByRole('heading', {
       name: /welcome to jam/i,
-    })
+    });
 
-    expect(heading).toBeInTheDocument()
-  })
-})
+    expect(heading).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Just a quick fix to get rid of these errors:

```
Error: xt-auth][error][client_fetch_error] 
    https://next-auth.js.org/errors#client_fetch_error session ReferenceError: fetch is not defined

Error: xt-auth][error][client_use_session_error] 
    https://next-auth.js.org/errors#client_use_session_error ReferenceError: fetch is not defined
```

during both local and deployment test runs, by mocking a session for jest.