### PR TITLE
Enables login on branch deploys, fixes cookie name

### DIFF
--- a/.github/workflows/branch-prs.yml
+++ b/.github/workflows/branch-prs.yml
@@ -37,6 +37,14 @@ jobs:
         with:
           node-version: 14.x
 
+      - name: Builds the expected branch deployment URL
+        id: branch-url
+        run: |
+          # we might have to do some char replacement, but this will work
+          # with our current branch name convention I think
+          URL="${{ github.head_ref}}--elated-austin-ae1db6.netlify.app"
+          echo "::set-output name=BRANCH_URL::$URL"
+
       - name: Create .env file
         uses: SpicyPizza/create-envfile@v1
         with:
@@ -44,7 +52,7 @@ jobs:
           envkey_AUTH0_ISSUER_BASE_URL: ${{ secrets.AUTH0_ISSUER_BASE_URL }}
           envkey_AUTH0_CLIENT_ID: ${{ secrets.AUTH0_CLIENT_ID }}
           envkey_AUTH0_CLIENT_SECRET: ${{ secrets.AUTH0_CLIENT_SECRET }}
-          envkey_NEXTAUTH_URL: ${{ secrets.NEXTAUTH_URL }}
+          envkey_NEXTAUTH_URL: ${{ steps.branch-url.outputs.BRANCH_URL }}
           file_name: '.env'
 
       - name: Add Firebase secret
@@ -58,9 +66,6 @@ jobs:
         run: |
           npm install -g yarn
           yarn install
-
-      # - name: 🧹 Run lint
-      #   run: npm run lint
 
       - name: 🐛 Run tests
         run: yarn test

--- a/pages/api/new-function.js
+++ b/pages/api/new-function.js
@@ -1,6 +1,8 @@
 import ensureAdmin from 'utils/admin-auth-middleware.js';
 
 export default async function handler(req, res) {
+  console.log(process.env);
+  console.log(process.env.NODE_ENV);
   try {
     const token = await ensureAdmin(req, res);
 

--- a/pages/api/new-function.js
+++ b/pages/api/new-function.js
@@ -1,8 +1,6 @@
 import ensureAdmin from 'utils/admin-auth-middleware.js';
 
 export default async function handler(req, res) {
-  console.log(process.env);
-  console.log(process.env.NODE_ENV);
   try {
     const token = await ensureAdmin(req, res);
 

--- a/utils/admin-auth-middleware.js
+++ b/utils/admin-auth-middleware.js
@@ -6,6 +6,12 @@ const client = jwksClient({
   jwksUri: 'https://rb-jams-dev.eu.auth0.com/.well-known/jwks.json',
 });
 
+const cookieSuffix = 'next-auth.session-token';
+const cookieName =
+  process.env.NODE_ENV === 'production'
+    ? `__Secure-${cookieSuffix}`
+    : cookieSuffix;
+
 function getKey(header, callback) {
   client.getSigningKey(header.kid, function (err, key) {
     var signingKey = key.publicKey || key.rsaPublicKey;
@@ -15,14 +21,14 @@ function getKey(header, callback) {
 
 export default function ensureAdmin(req, res) {
   return new Promise((resolve, reject) => {
-    let cookies = new Cookies(req, res);
-    let token = cookies.get('next-auth.session-token');
+    const cookies = new Cookies(req, res);
+    const token = cookies.get(cookieName);
 
     if (!token) return reject({ message: 'No session found' });
 
-    let decodedToken = jwt.decode(token);
+    const decodedToken = jwt.decode(token);
 
-    let accessToken = decodedToken.accessToken;
+    const accessToken = decodedToken.accessToken;
 
     jwt.verify(
       accessToken,


### PR DESCRIPTION
This PR ended up fixing two separate issues:

 - we currently can't login on branch (PR) deploys because the NEXTAUTH_URL is always being set to the live production site. This changes that and makes it the (expected) deploy URL (we have a bit of a chicken an egg situation here as we need this to build but only know the URL after deployment) so we can now login from everywhere.

 - currently creating a new Jam is broken because the cookie name on the live Netlify different from what I was expecting locally, and `ensureAdmin` doesn't find it. This might be because we're using https on deployments and not locally, so the cookies are being set with the `__Secure-` prefix. This fixes that as well, taking into account NODE_ENV.